### PR TITLE
Optionally set subname for installed sub

### DIFF
--- a/lib/Sub/Install.pm
+++ b/lib/Sub/Install.pm
@@ -13,7 +13,8 @@ use Scalar::Util ();
   Sub::Install::install_sub({
     code => sub { ... },
     into => $package,
-    as   => $subname
+    as   => $subname,
+    name => 1,
   });
 
 =head1 DESCRIPTION
@@ -28,6 +29,7 @@ see them.
    code => \&subroutine,
    into => "Finance::Shady",
    as   => 'launder',
+   name => 1,
   });
 
 This routine installs a given code reference into a package as a normal
@@ -63,6 +65,10 @@ is the same as:
     code => Person::InPain->can('twitch'),
     as   => 'dance',
   });
+
+If C<name> is true, the subroutine will have its name set according to where it
+is installed to, to identify it in stack traces. This feature is available
+since Sub::Install 0.929, and requires L<Sub::Util> 1.40+.
 
 =func reinstall_sub
 
@@ -113,6 +119,13 @@ sub _build_public_installer {
 
     Carp::croak "couldn't determine name under which to install subroutine"
       unless $arg->{as};
+
+    if ($arg->{name}) {
+      require Sub::Util;
+      Sub::Util->VERSION('1.40');
+      my $name = "$arg->{into}::$arg->{as}";
+      $arg->{code} = Sub::Util::set_subname($name, $arg->{code});
+    }
 
     $installer->(@$arg{qw(into as code) });
   }


### PR DESCRIPTION
Setting the subname for installed subs is useful for stack traces and other introspection. I'm not sure if there's a way to apply this feature to install_installers.